### PR TITLE
Minor typo and em-dash

### DIFF
--- a/petrov_day.tex
+++ b/petrov_day.tex
@@ -1426,7 +1426,7 @@ those advanced capabilities.
 
 But sensors in South Korea, China, and the US indicated that whatever the
 Hermit Kingdom exploded underground on Sunday was more powerful than the atomic
-weapons the US used during World War II—a benchmark North Korea had not
+weapons the US used during World War II---a benchmark North Korea had not
 definitively topped before.}{Lily Hay Newman, Wired.com (2017)}
 } %}}}
 % Petrov died {{{

--- a/petrov_day.tex
+++ b/petrov_day.tex
@@ -1126,7 +1126,7 @@ increase in the world death rate, although many lives could be saved through
 dramatic programs to "stretch" the carrying capacity of the earth by increasing
 food production and providing for more equitable distribution of whatever food
 is available. But these programs will only provide a stay of execution unless
-they are accompanied by determined and successful efforts to addrses population
+they are accompanied by determined and successful efforts to address population
 control. Population control is the conscious regulation of the numbers of human
 beings to meet the needs not just of individual families, but of society as a
 whole.


### PR DESCRIPTION
Fixes a minor typo in the Paul Ehrlich quote ("addrses") and replaces an em-dash with "---".